### PR TITLE
Refactor getip server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM macpaw/internship
 
-ENV GOPATH=/go
+ENV GOPATH /go
+ENV GETIP_PORT 8080
 
 RUN apt install -y vim curl wget tree grep sed zip \
                    build-essential logrotate golang

--- a/getip/main.go
+++ b/getip/main.go
@@ -2,12 +2,19 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"net/http"
+	"os"
 )
 
 func main() {
+	serverPort, exists := os.LookupEnv("GETIP_PORT")
+
+	if !exists {
+		fmt.Println("Enviroment variable GETIP_PORT is not set. Using 3000.")
+		serverPort = "3000"
+	}
+
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
 		ip, port, err := net.SplitHostPort(req.RemoteAddr)
 
@@ -29,5 +36,7 @@ func main() {
 		fmt.Fprintf(w, "<p>Forwarded for: %s</p>", forward)
 	})
 
-	log.Fatal(http.ListenAndServe(":8080", nil))
+	fmt.Println("Server is running...")
+
+	http.ListenAndServe(":"+serverPort, nil)
 }


### PR DESCRIPTION
Added ability to specify server port using GETIP_PORT env.
Get rid of log library.

Set GETIP_PORT to 8080 in Dockerfile.